### PR TITLE
Remove commas from tags

### DIFF
--- a/_scripts/copy-alt-on-click.md
+++ b/_scripts/copy-alt-on-click.md
@@ -2,7 +2,7 @@
 title: Dear Console, allow me to copy the alternative text of images by clicking them
 name: Allow me to copy the alternative text of images by clicking them
 codeexample: '$(±body±).addEventListener(±click±,e => { let alt = e.target.alt; if (alt) { navigator.clipboard.writeText(alt); console.log(±Copied:\n± + alt); e.preventDefault() } })'
-tags: accessibility, images, alternativetext
+tags: accessibility images alternativetext
 layout: default
 ---
 


### PR DESCRIPTION
As per https://jekyllrb.com/docs/posts/#tags
"it will automatically split a string entry
if it contains whitespace."

Commas are not treated as split characters.
Because this file had commas in it, an additional
tag, which was empty, was being rendered.

Resolves #11